### PR TITLE
list hooks; pretty much useless

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import urllib
+
+import requests
+
+from client import get_token
+
+if __name__ == '__main__':
+    headers = {
+        'Accept': 'application/vnd.github.sersi-preview+json',
+        'Authorization': 'token %s' % get_token()
+    }
+    params = {}
+
+    org_hooks_url = '%s?%s' % (
+        'https://api.github.com/orgs/%s/hooks' % 'mozilla',
+        urllib.urlencode(params)
+    )
+    resp = requests.get(org_hooks_url, headers=headers)
+
+    hooks = resp.json()
+    for hook in hooks:
+        print hook['config']['url']


### PR DESCRIPTION
Only creating this to make the work public. It's useless though. Per [the scopes & restrictions of the GitHub API](https://developer.github.com/v3/orgs/hooks/#scopes--restrictions) this doesn't allow users to list, view, or edit webhooks created by OAuth applications. :(

So, our best way to audit web hooks is to manually scan [the Audit log for action:hook.create events](https://github.com/orgs/mozilla/audit-log?q=action%3Ahook.create).