### PR TITLE
print user['login'] instead of user.username

### DIFF
--- a/admins.py
+++ b/admins.py
@@ -22,4 +22,4 @@ if __name__ == '__main__':
     bad_admins = resp.json()
     print 'The following admins DO NOT HAVE 2FA:'
     for a in bad_admins:
-        print a.username
+        print a['login']


### PR DESCRIPTION
I guess the GitHub response format has changed. It broke when I tried to use `.username`