### PR TITLE
Support interim API

### DIFF
--- a/admins.py
+++ b/admins.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     # for orgs that don't yet support the new API, the 'role' filter is
     # not honored. Filter those out by checking the 'site_admin' key.
     real_admins = [x for x in bad_admins if x['site_admin']]
-    if len(real_admins):
+    if real_admins:
         print 'The following admins DO NOT HAVE 2FA:'
         for a in real_admins:
             print a['login']

--- a/admins.py
+++ b/admins.py
@@ -7,7 +7,9 @@ from client import get_token
 
 if __name__ == '__main__':
     headers = {
-        'Accept': 'application/vnd.github.moondragon+json',
+        # new api requires new accept per
+        # https://developer.github.com/changes/2015-06-24-api-enhancements-for-working-with-organization-permissions/#preview-period
+        'Accept': 'application/vnd.github.ironman-preview+json',
         'Authorization': 'token %s' % get_token()
     }
     params = {'filter': '2fa_disabled',
@@ -20,6 +22,13 @@ if __name__ == '__main__':
     resp = requests.get(admins_with_1fa_url, headers=headers)
 
     bad_admins = resp.json()
-    print 'The following admins DO NOT HAVE 2FA:'
-    for a in bad_admins:
-        print a['login']
+
+    # for orgs that don't yet support the new API, the 'role' filter is
+    # not honored. Filter those out by checking the 'site_admin' key.
+    real_admins = [x for x in bad_admins if x['site_admin']]
+    if len(real_admins):
+        print 'The following admins DO NOT HAVE 2FA:'
+        for a in real_admins:
+            print a['login']
+    else:
+        print 'Congrats! All admins have 2FA enabled!'


### PR DESCRIPTION
Right now, some organizations are capable of the new API call, and
others are not. This code now tries the new API, but also filters
results we don't want from the old API response.

Fixes #5 for various orgs I can try: mozilla (new), mozillatw, mozilla-b2g (old)